### PR TITLE
Changing CORS origin from localhost:5173 to the live site URL. This m…

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -13,7 +13,7 @@ const PORT = process.env.PORT || 3001;
 
 // Apply Middleware BEFORE Routes
 app.use(cors({
-  origin: 'http://localhost:5173', // Allow frontend requests
+  origin: 'https://stattrick.onrender.com/', // Allow frontend requests
   methods: ['GET', 'POST', 'PUT', 'DELETE'],
   allowedHeaders: ['Content-Type', 'Authorization'],
 }));


### PR DESCRIPTION
…ay be the issue causing API calls to fail on the live site while they are working on the localhost in the development environment.